### PR TITLE
Main flow update

### DIFF
--- a/services/app/src/constants.ts
+++ b/services/app/src/constants.ts
@@ -1,1 +1,4 @@
 export const BLOCK_INTERVAL = 8
+
+// Round the service should start posting values
+export const STARTING_ROUND = parseInt(process.env.STARTING_ROUND, 10)

--- a/services/app/src/index.ts
+++ b/services/app/src/index.ts
@@ -1,4 +1,9 @@
 import 'dotenv/config'
+import * as Sentry from '@sentry/node'
 import loop from './loop'
+
+Sentry.init({
+  environment: process.env.NODE_ENV,
+})
 
 loop()

--- a/services/app/src/utils/grpc-client.ts
+++ b/services/app/src/utils/grpc-client.ts
@@ -4,14 +4,18 @@ import { ProtoGrpcType } from '../proto/vrf'
 import path from 'path'
 import { promisify } from 'util'
 import logger from '../logger'
+import { Logger } from 'winston'
+import { VRFInput } from '../proto/vrf/VRFInput'
 
 const PROTO_PATH = path.join(__dirname, '../proto/vrf.proto')
-
 const packageDefinition = protoLoader.loadSync(PROTO_PATH)
 const proto = grpc.loadPackageDefinition(packageDefinition) as unknown as ProtoGrpcType
+
+const getDeadline = () => {
+  return new Date(Date.now() + 5000)
+}
 const client = new proto.vrf.Vrf(process.env.VRF_GRPC_HOST as string, grpc.credentials.createInsecure())
-const deadline = new Date()
-deadline.setSeconds(deadline.getSeconds() + 10)
+const deadline = getDeadline()
 
 client.waitForReady(deadline, (error?: Error) => {
   if (error) {
@@ -21,6 +25,16 @@ client.waitForReady(deadline, (error?: Error) => {
   }
 })
 
-export const generateProof = promisify(client.generateProof.bind(client))
+const generateProof = promisify(client.generateProof.bind(client))
+
+export const getVrfProof = async (vrfInput: string, logger: Logger): Promise<string | undefined> => {
+  try {
+    const result = await generateProof({ vrfInput } as VRFInput, { deadline: getDeadline() })
+    return result.vrfProof
+  } catch (error) {
+    logger.error(error)
+    throw error
+  }
+}
 
 export default client


### PR DESCRIPTION
# Description

Updates the main flow to first get the expected next round to create a transaction and then create the transaction.
Since we will have multiple instances concurrently trying o post the transaction and because in case of a disaster or just a service/process restart we can't rely only on the latest block instead we need to grab the last block accepted by the smart contract.