### PR TITLE
VRF: Chore/RB-24 Add trace id to logging

### DIFF
--- a/services/app/src/loop.ts
+++ b/services/app/src/loop.ts
@@ -6,7 +6,8 @@ import { getVrfProof } from './utils/grpc-client'
 import { randomUUID } from 'crypto'
 
 const mainFlow = async () => {
-  const logger = parentLogger.child({ traceId: randomUUID() })
+  const traceId = randomUUID()
+  const logger = parentLogger.child({ traceId })
   try {
     const lastRound = await getLastRound()
     if (!lastRound) {
@@ -28,7 +29,7 @@ const mainFlow = async () => {
     const vrfInput = buildVrfInput(nextExpectedRound, blockSeed)
 
     logger.info('Getting the proof hash', { vrfInput })
-    const vrfProof = await getVrfProof(vrfInput, logger)
+    const vrfProof = await getVrfProof(vrfInput, logger, traceId)
     logger.debug({ nextExpectedRound, blockSeed, vrfInput, vrfProof })
 
     logger.info('Submiting the value', { vrfInput })

--- a/services/app/src/utils/grpc-client.ts
+++ b/services/app/src/utils/grpc-client.ts
@@ -27,9 +27,12 @@ client.waitForReady(deadline, (error?: Error) => {
 
 const generateProof = promisify(client.generateProof.bind(client))
 
-export const getVrfProof = async (vrfInput: string, logger: Logger): Promise<string | undefined> => {
+export const getVrfProof = async (vrfInput: string, logger: Logger, traceId: string): Promise<string | undefined> => {
   try {
-    const result = await generateProof({ vrfInput } as VRFInput, { deadline: getDeadline() })
+    const metadata = new grpc.Metadata()
+    metadata.add('trace-id', traceId)
+
+    const result = await generateProof({ vrfInput } as VRFInput, metadata, { deadline: getDeadline() })
     return result.vrfProof
   } catch (error) {
     logger.error(error)

--- a/services/vrf/src/server.ts
+++ b/services/vrf/src/server.ts
@@ -10,7 +10,8 @@ import { vrfProve } from './utils/libsodium-wrapper'
 
 const server: VrfHandlers = {
   GenerateProof: async (call: grpc.ServerUnaryCall<VRFInput, VRFProof>, callback: grpc.sendUnaryData<VRFProof>) => {
-    const logger = parentLogger.child({ traceId: randomUUID() })
+    const traceId = call.metadata.get('trace-id')[0]
+    const logger = parentLogger.child({ traceId })
     const vrfInputString = Buffer.from(call.request.vrfInput).toString()
     try {
       logger.info('Generate proof handler', { vrfInputString })


### PR DESCRIPTION
# Description
As implemented in app service, vrf service should have a trace id into the logs for a better debug/troubleshooting.

## Link to card
- [RB-24](https://appliedblockchain.atlassian.net/browse/RB-24)