### PR TITLE
Feature/RB4 - Add CI test to build docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,9 +73,6 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 20.10.2
-      - restore_cache:
-          keys:
-            - app-{{ checksum "services/app/package.json" }}
       - run:
           name: Run docker build
           command: |-


### PR DESCRIPTION
# Description
Add docker build to CI Pipeline in order to test project build.

# Task
[RB-4](https://appliedblockchain.atlassian.net/browse/RB-4)