### PR TITLE
add dd tracing for the submit method

### DIFF
--- a/stack-eks/app/dev/app.daemonset.yaml
+++ b/stack-eks/app/dev/app.daemonset.yaml
@@ -55,7 +55,7 @@ spec:
                 name: app-env-vars
                 key: SERVICE_MNEMONIC
           - name: SERVICE_ACCOUNT_MINIMUM_BALANCE
-            value: "200000000"
+            value: "50000000"
           - name: DD_ENV
             value: "development randomness-oracle-env-03-eks"
           - name: DD_VERSION


### PR DESCRIPTION
# Description

The most time spent from start to finish on a successfully submitted value is submitting the transaction. This is taking from 6s to 9s on my tests. 
This PR adds tracing to the submit method to improve the metrics we can get out of this.